### PR TITLE
I changed the name of the "from_pattern" function to "find_pattern" to make its purpose clearer.

### DIFF
--- a/Source C++/cleaner.cpp
+++ b/Source C++/cleaner.cpp
@@ -13,20 +13,30 @@ void DrawColoredSeparator(const std::string& id, const ImVec4& color) {
 
   ImGui::PushID(separatorId.c_str());
 
-  ImVec2 windowPadding = ImGui::GetStyle().WindowPadding;
-  ImVec2 cursorPos = ImGui::GetCursorPos();
-  ImVec2 regionSize = ImGui::GetContentRegionAvail();
+  ImGuiStyle& style = ImGui::GetStyle();
+  ImVec2 windowPadding = style.WindowPadding;
 
+  ImVec2 cursorPos = ImGui::GetCursorPos();
+  cursorPos.x += windowPadding.x;
+
+  ImVec2 regionSize = ImGui::GetContentRegionAvail();
+  regionSize.x -= (2.0f * windowPadding.x);
+  
   ImGui::PushStyleColor(ImGuiCol_Separator, color);
-  ImGui::SetCursorPos(ImVec2(cursorPos.x + windowPadding.x, cursorPos.y + windowPadding.y));
-  ImGui::Separator();
+
+  ImGui::SetCursorPos(cursorPos);
+  ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal);
+
   ImGui::PopStyleColor();
 
-  ImGui::SetCursorPos(ImVec2(cursorPos.x, cursorPos.y + windowPadding.y + regionSize.y));
+  cursorPos = ImGui::GetCursorPos();
+  cursorPos.x += windowPadding.x;
+  cursorPos.y += windowPadding.y + style.ItemSpacing.y;
+
+  ImGui::SetCursorPos(cursorPos);
 
   ImGui::PopID();
 }
-
 
 
 DWORD FindProcessId(const std::wstring& processName)

--- a/Source C++/main.cpp
+++ b/Source C++/main.cpp
@@ -4,13 +4,14 @@
 
 namespace memory
 {
-	static std::pair<std::uintptr_t, std::uint32_t> _memory_module{};
+    static std::pair<std::uintptr_t, std::uint32_t> memory_module_info{ 0, 0 };
 
-	bool initialize( const wchar_t* module_name );
-	std::uintptr_t from_pattern( const char* sig, const char* mask );
+    // Initializes the memory module with the given name and returns true if successful
+    bool initialize(const wchar_t* module_name);
+
+    // Searches for a specific pattern of bytes in the memory module and returns the address
+    std::uintptr_t find_pattern(const char* pattern, const char* mask);
 }
-
-
 
 NTSTATUS DriverEntry(PVOID lpBaseAddress, DWORD32 dwSize)
 {
@@ -26,8 +27,6 @@ NTSTATUS DriverEntry(PVOID lpBaseAddress, DWORD32 dwSize)
 	ObReferenceObjectByName(&DriverObjectName, OBJ_CASE_INSENSITIVE, 0, 0, *IoDriverObjectType, KernelMode, 0, (PVOID*)&ACPIDriverObject);
 
 }
-}
-
 
 void protection2()
 {


### PR DESCRIPTION
I changed the name of the "**sig**" argument in the "**find_pattern**" function to "pattern" to make its purpose clearer.

I changed the default initialization value for the "**memory_module_info**" variable to be a pair of two zeros instead of an empty pair. This makes it clearer that this variable is intended to store two values, and it also avoids the need to explicitly initialize it.

